### PR TITLE
Fix for issue #54

### DIFF
--- a/tools/c3s/c3s.sh
+++ b/tools/c3s/c3s.sh
@@ -7,9 +7,14 @@ if [ -f download.tar.gz ]; then
    cdo -f nc -t ecmwf copy tmpg.grib tmp.nc
 elif [ -f download.zip ]; then
    unzip download.zip
-   cat *.grib > tmp.grib
-   cdo setgridtype,regular tmp.grib tmpg.grib
-   cdo -f nc -t ecmwf copy tmpg.grib tmp.nc
+   files=(*.nc)
+   if [ -e "${files[0]}" ]; then
+     mv ${files[0]} tmp.nc
+   else
+     cat *.grib > tmp.grib
+     cdo setgridtype,regular tmp.grib tmpg.grib
+     cdo -f nc -t ecmwf copy tmpg.grib tmp.nc
+   fi
 elif [ -f download.grib ]; then
    cdo -f nc -t ecmwf copy download.grib tmp.nc
 elif [ -f download.nc ]; then

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -1,5 +1,5 @@
-<tool id="c3s" name="Copernicus Climate Data Store" version="0.1.0">
-    <description>for retrieveing climate data</description>
+<tool id="c3s" name="Copernicus Climate Data Store" version="0.2.0">
+    <description>for retrieving climate data</description>
     <requirements>
         <requirement type="package" version="3">python</requirement>
         <requirement type="package" version="0.5.1">cdsapi</requirement>


### PR DESCRIPTION
Hi, 

I've started to use the EU Galaxy platform as part of an OGC Open Science Persistent Demonstrator Pilot, and I wanted to use this tool as part of a demonstration workflow. However, what's downloaded within the zip file I'm retrieving from CDS is a NetCDF rather than GRIB file. Looking at the repo issues, I noticed this bug had already been reported under issue #54 So, I'm proposing a fix to that bug.

Best Wishes, Sam