### PR TITLE
Update for new CDS API

### DIFF
--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -1,5 +1,14 @@
-<tool id="c3s" name="Copernicus Climate Data Store" version="0.3.0">
+<tool id="c3s" name="Copernicus Climate Data Store" version="0.3.0" profile="23.0">
     <description>for retrieving climate data</description>
+    <edam_topics>
+        <edam_topic>topic_3855</edam_topic>
+        <edam_topic>topic_3318</edam_topic>
+      </edam_topics>
+      <edam_operations>
+        <edam_operation>operation_2422</edam_operation>
+        <edam_operation>operation_3357</edam_operation>
+        <edam_operation>operation_0335</edam_operation>
+      </edam_operations>
     <requirements>
         <requirement type="package" version="3.8">python</requirement>
         <requirement type="package" version="0.7.3">cdsapi</requirement>
@@ -11,18 +20,18 @@
        export HOME=`pwd`  &&
        #set $c3s_cds_apikey = $__user__.extra_preferences.get('c3s_account|c3s_cds_apikey', "")
        #if $c3s_cds_apikey == ""
-	    echo "Error. Set your credentials via: User -> Preferences -> Manage Information"  &&
+	    echo "Error. Set your credentials via: User -> Preferences -> Manage Information" &&
        #else
             cp '$cds_key_file' .cdsapirc &&
        #end if
        #if str($is_file.has_req).strip() == 'yes'
             python3 '$__tool_directory__/c3s_retrieve.py' 
-	             --request '$is_file.api_req_file' --output request.txt       &&
+	             --request '$is_file.api_req_file' --output request.txt  &&
        #else
             python3 '$__tool_directory__/c3s_retrieve.py' 
-	             --request $req_from_paste --output request.txt               &&
+	             --request $req_from_paste --output request.txt &&
        #end if
-       bash $__tool_directory__/c3s.sh                                    &&
+       bash $__tool_directory__/c3s.sh &&
        echo "C3S data retrieval is done"
     ]]></command>
     <configfiles>
@@ -52,8 +61,8 @@ $is_file.api_req_text
         </conditional>
     </inputs>
     <outputs>
-        <data name="request" format="txt" from_work_dir="request.txt"/>
-        <data name="ofilename" format="netcdf" from_work_dir="tmp.nc"/>
+        <data name="request" format="txt" from_work_dir="request.txt" label="${tool.name} on ${on_string}: request script"/>
+        <data name="ofilename" format="netcdf" from_work_dir="tmp.nc" label="${tool.name} on ${on_string}: NC"/>
     </outputs>
     <tests>
         <test>
@@ -78,27 +87,22 @@ $is_file.api_req_text
             </output>
         </test>
     </tests>
-    <edam_topics>
-      <edam_topic>topic_3855</edam_topic>
-      <edam_topic>topic_3318</edam_topic>
-    </edam_topics>
-    <edam_operations>
-      <edam_operation>operation_2422</edam_operation>
-      <edam_operation>operation_3357</edam_operation>
-      <edam_operation>operation_0335</edam_operation>
-    </edam_operations>
     <help><![CDATA[
 
 **Copernicus Climate Data Store (C3S)**
-=======================================================================================================
+=======================================
 
 This tool is a wrapper to retrieve data from the Copernicus Climate Data Store.
+
 - It allows to retrieve data from the Copernicus climate Data Store.
 - Any user willing to use this tool needs to `create a new account <https://cds.climate.copernicus.eu/>`_.
 - Set your CDS API Key via: User -> Preferences -> Manage Information"
 - Documentation on where to get the CDS API key can be found `here <https://cds.climate.copernicus.eu/how-to-api>`_.
 - Compose your request directly on C3S and extract the relevant information, which should be put in the input field "Request" or saved in a file. The format should be, for example::
+
+
     import cdsapi
+    
     c = cdsapi.Client()
     c.retrieve(
         'reanalysis-era5-single-levels-monthly-means',
@@ -112,7 +116,10 @@ This tool is a wrapper to retrieve data from the Copernicus Climate Data Store.
             'area': [60, 10, 59.5, 10.5],
         },
         'download.nc')
+
+
 - Be aware that for being able to download dataset from C3S, users also need to agree to licensing terms for each dataset of interest on the C3S website.
+
 License:
 ~~~~~~~~
 

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -104,10 +104,7 @@ c.retrieve(
         'year': '2020',
         'month': '12',
         'time': '00:00',
-        'area': [
-            60, 10, 59.5,
-            10.5,
-        ],
+        'area': [60, 10, 59.5, 10.5 ],
     },
     'download.nc')
 
@@ -120,9 +117,6 @@ Generated using Copernicus Climate Change Service information [2021]
 Neither the European Commission nor ECMWF is responsible for any use 
 that may be made of the Copernicus information or data it contains.
     ]]></help>
-    <citations>
-	<citation type="text">Copernicus Climate Change Service (2024)</citation>
-    </citations>
     <edam_topics>
       <edam_topic>topic_3855</edam_topic>
       <edam_topic>topic_3318</edam_topic>
@@ -132,4 +126,8 @@ that may be made of the Copernicus information or data it contains.
       <edam_operation>operation_3357</edam_operation>
       <edam_operation>operation_0335</edam_operation>
     </edam_operations>
+    <citations>
+	<citation type="bibtext">
+	@misc{C3S2024,author={Copernicus Climate Change Service},year={2024}}</citation>
+    </citations>
 </tool>

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -28,7 +28,7 @@
     <configfiles>
         <configfile name="cds_key_file"><![CDATA[
 #set $c3s_cds_apikey = $__user__.extra_preferences.get('c3s_account|c3s_cds_apikey', "")
-         url: https://cds.climate.copernicus.eu/api/v2
+         url: https://cds.climate.copernicus.eu/api
          key: $c3s_cds_apikey
         ]]></configfile>
         <configfile name="req_from_paste"><![CDATA[
@@ -86,11 +86,32 @@ $is_file.api_req_text
 This tool is a wrapper to retrieve data from the Copernicus Climate Data Store.
 
 - It allows to retrieve data from the Copernicus climate Data Store.
-- Any user willing to use this tool needs to `create a new account <https://cds.climate.copernicus.eu/user/register?destination=%2F%23!%2Fhome>`_.
+- Any user willing to use this tool needs to `create a new account <https://cds.climate.copernicus.eu/>`_.
 - Set your CDS API Key via: User -> Preferences -> Manage Information"
-- Documentation on where to get the CDS API key can be found `here <https://cds.climate.copernicus.eu/api-how-to>`_.
-- Compose your request directly on C3S and copy/paste it in the input field "Request" or save it in a file.
-- Be aware that for being able to download dataset from C3S, users also need to agree to their term of use (Licence to use Copernicus Products) on the C3S website.
+- Documentation on where to get the CDS API key can be found `here <https://cds.climate.copernicus.eu/how-to-api>`_.
+- Compose your request directly on C3S and extract the relevant information, which should be put in the input field "Request" or saved in a file. The format should be, for example:
+
+import cdsapi
+
+c = cdsapi.Client()
+
+c.retrieve(
+    'reanalysis-era5-single-levels-monthly-means',
+    {
+        'data_format': 'netcdf',
+        'product_type': 'monthly_averaged_reanalysis',
+        'variable': '2m_temperature',
+        'year': '2020',
+        'month': '12',
+        'time': '00:00',
+        'area': [
+            60, 10, 59.5,
+            10.5,
+        ],
+    },
+    'download.nc')
+
+- Be aware that for being able to download dataset from C3S, users also need to agree to licensing terms for each dataset of interest on the C3S website.
 
 License:
 ~~~~~~~~
@@ -100,7 +121,7 @@ Neither the European Commission nor ECMWF is responsible for any use
 that may be made of the Copernicus information or data it contains.
     ]]></help>
     <citations>
-
+	<citation type="text">Copernicus Climate Change Service (2024)</citation>
     </citations>
     <edam_topics>
       <edam_topic>topic_3855</edam_topic>

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -84,32 +84,26 @@ $is_file.api_req_text
 =======================================================================================================
 
 This tool is a wrapper to retrieve data from the Copernicus Climate Data Store.
-
 - It allows to retrieve data from the Copernicus climate Data Store.
 - Any user willing to use this tool needs to `create a new account <https://cds.climate.copernicus.eu/>`_.
 - Set your CDS API Key via: User -> Preferences -> Manage Information"
 - Documentation on where to get the CDS API key can be found `here <https://cds.climate.copernicus.eu/how-to-api>`_.
-- Compose your request directly on C3S and extract the relevant information, which should be put in the input field "Request" or saved in a file. The format should be, for example:
-
-import cdsapi
-
-c = cdsapi.Client()
-
-c.retrieve(
-    'reanalysis-era5-single-levels-monthly-means',
-    {
-        'data_format': 'netcdf',
-        'product_type': 'monthly_averaged_reanalysis',
-        'variable': '2m_temperature',
-        'year': '2020',
-        'month': '12',
-        'time': '00:00',
-        'area': [60, 10, 59.5, 10.5],
-    },
-    'download.nc')
-
+- Compose your request directly on C3S and extract the relevant information, which should be put in the input field "Request" or saved in a file. The format should be, for example::
+    import cdsapi
+    c = cdsapi.Client()
+    c.retrieve(
+        'reanalysis-era5-single-levels-monthly-means',
+        {
+            'data_format': 'netcdf',
+            'product_type': 'monthly_averaged_reanalysis',
+            'variable': '2m_temperature',
+            'year': '2020',
+            'month': '12',
+            'time': '00:00',
+            'area': [60, 10, 59.5, 10.5],
+        },
+        'download.nc')
 - Be aware that for being able to download dataset from C3S, users also need to agree to licensing terms for each dataset of interest on the C3S website.
-
 License:
 ~~~~~~~~
 

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -78,6 +78,15 @@ $is_file.api_req_text
             </output>
         </test>
     </tests>
+    <edam_topics>
+      <edam_topic>topic_3855</edam_topic>
+      <edam_topic>topic_3318</edam_topic>
+    </edam_topics>
+    <edam_operations>
+      <edam_operation>operation_2422</edam_operation>
+      <edam_operation>operation_3357</edam_operation>
+      <edam_operation>operation_0335</edam_operation>
+    </edam_operations>
     <help><![CDATA[
 
 **Copernicus Climate Data Store (C3S)**
@@ -111,15 +120,6 @@ Generated using Copernicus Climate Change Service information [2024]
 Neither the European Commission nor ECMWF is responsible for any use 
 that may be made of the Copernicus information or data it contains.
     ]]></help>
-    <edam_topics>
-      <edam_topic>topic_3855</edam_topic>
-      <edam_topic>topic_3318</edam_topic>
-    </edam_topics>
-    <edam_operations>
-      <edam_operation>operation_2422</edam_operation>
-      <edam_operation>operation_3357</edam_operation>
-      <edam_operation>operation_0335</edam_operation>
-    </edam_operations>
     <citations>
 	<citation type="bibtex">
 	@misc{C3S2024,author={Copernicus Climate Change Service},year={2024}}</citation>

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -1,9 +1,9 @@
-<tool id="c3s" name="Copernicus Climate Data Store" version="0.2.0">
+<tool id="c3s" name="Copernicus Climate Data Store" version="0.3.0">
     <description>for retrieving climate data</description>
     <requirements>
-        <requirement type="package" version="3">python</requirement>
-        <requirement type="package" version="0.5.1">cdsapi</requirement>
-        <requirement type="package" version="1.9.9">cdo</requirement>
+        <requirement type="package" version="3.8">python</requirement>
+        <requirement type="package" version="0.7.3">cdsapi</requirement>
+        <requirement type="package" version="2.4.4">cdo</requirement>
         <requirement type="package" version="1.34">tar</requirement>
         <requirement type="package" version="6.0">unzip</requirement>
     </requirements>
@@ -61,7 +61,7 @@ $is_file.api_req_text
             <output name="request" ftype="txt">
               <assert_contents>
                   <has_text text="dataset to retrieve: reanalysis-era5-single-levels-monthly-means" />
-                  <has_text text="'format': 'netcdf'" />
+                  <has_text text="'data_format': 'netcdf'" />
                   <has_text text="'product_type': 'monthly_averaged_reanalysis'" />
                   <has_text text="'variable': '2m_temperature'" />
                   <has_text text="'year': '2020'" />

--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -104,7 +104,7 @@ c.retrieve(
         'year': '2020',
         'month': '12',
         'time': '00:00',
-        'area': [60, 10, 59.5, 10.5 ],
+        'area': [60, 10, 59.5, 10.5],
     },
     'download.nc')
 
@@ -113,7 +113,7 @@ c.retrieve(
 License:
 ~~~~~~~~
 
-Generated using Copernicus Climate Change Service information [2021]
+Generated using Copernicus Climate Change Service information [2024]
 Neither the European Commission nor ECMWF is responsible for any use 
 that may be made of the Copernicus information or data it contains.
     ]]></help>
@@ -127,7 +127,7 @@ that may be made of the Copernicus information or data it contains.
       <edam_operation>operation_0335</edam_operation>
     </edam_operations>
     <citations>
-	<citation type="bibtext">
+	<citation type="bibtex">
 	@misc{C3S2024,author={Copernicus Climate Change Service},year={2024}}</citation>
     </citations>
 </tool>

--- a/tools/c3s/test-data/input.txt
+++ b/tools/c3s/test-data/input.txt
@@ -5,7 +5,7 @@ c = cdsapi.Client()
 c.retrieve(
     'reanalysis-era5-single-levels-monthly-means',
     {
-        'format': 'netcdf',
+        'data_format': 'netcdf',
         'product_type': 'monthly_averaged_reanalysis',
         'variable': '2m_temperature',
         'year': '2020',


### PR DESCRIPTION
@bgruening Sorry, but I've got another pull request. Yesterday, ECMWF released the new version of the API https://confluence.ecmwf.int/display/CKB/Please+read%3A+CDS+and+ADS+migrating+to+new+infrastructure%3A+Common+Data+Store+%28CDS%29+Engine so older versions of the CDS API call don't work. 

I've updated the tool to comply with the new API, primarily up versioning the Python libraries, but also a slight change in how the data is called. I've updated the documentation.

The current test doesn't actually test if data is downloaded, just that the API call text is as expected. So, I'm not sure if this needs an improvement.