### PR TITLE
psy-maps: Adding matplotlib explicitly

### DIFF
--- a/tools/psy-maps/psy-maps.xml
+++ b/tools/psy-maps/psy-maps.xml
@@ -1,4 +1,4 @@
-<tool id="psy_maps" name="map plot" version="1.3.0" profile="23.0">
+<tool id="psy_maps" name="map plot" version="1.3.1" profile="23.0">
     <description>gridded (lat/lon) netCDF data</description>
     <edam_topics>
       <edam_topic>topic_3855</edam_topic>
@@ -9,6 +9,7 @@
     </edam_operations>
     <requirements>
         <requirement type="package" version="3">python</requirement>
+        <requirement type="package" version="3.9.2">matplotlib</requirement>
         <requirement type="package" version="1.4.3">psyplot</requirement>
         <requirement type="package" version="1.4.2">psy-maps</requirement>
         <requirement type="package" version="1.4.0">psy-reg</requirement>


### PR DESCRIPTION
@bgruening I'm pleased to let you know the c3s tool update worked, but unfortunately the update to psy-maps is reporting a bug:

![image](https://github.com/user-attachments/assets/190b62b2-7b5b-412f-8bde-ab8a1df41832)

I think this is because the planemo virtual environment contains matplotlib, but when run operationally in Galaxy, it is not available. So, I've added matplotlib explicitly to the xml file.
