### PR TITLE
Add required files section to c3s.xml and trigger the Tool Shed push

### DIFF
--- a/tools/c3s/c3s.xml
+++ b/tools/c3s/c3s.xml
@@ -19,6 +19,10 @@
             <secret name="key" inject_as_env="CDS_API_KEY" optional="false" label="CDS API key" description="Your Copernicus climate Data Store API key."/>
         </credentials>
     </requirements>
+	<required_files>
+        <include path="c3s_retrieve.py"/>
+		<include path="c3s.sh"/>
+    </required_files>
     <command detect_errors="exit_code"><![CDATA[
        export HOME=`pwd`  &&
 		


### PR DESCRIPTION
Add a required files section to c3s.xml and trigger the Tool Shed push as the tool does not seem to have been updated in the Tool Shed and in Galaxy despite the previous merging. @bgruening will that be enough?

ping @Marie59 